### PR TITLE
Fixed strings in arithmetic expressions

### DIFF
--- a/spectrecoin_rpc_ui.sh
+++ b/spectrecoin_rpc_ui.sh
@@ -969,22 +969,22 @@ calculateLayout() {
     local _max_buff
     POS_Y_MENU=0
     _max_buff=$(($(tput cols) / 2))
-    _max_buff=$((45>${_max_buff}?"45":${_max_buff}))
-    SIZE_X_MENU=$((60<${_max_buff}?"60":${_max_buff}))
+    _max_buff=$((45>${_max_buff}?45:${_max_buff}))
+    SIZE_X_MENU=$((60<${_max_buff}?60:${_max_buff}))
     SIZE_Y_MENU=13
 
     #Size for the displayed transactions in main menu
     _max_buff=$(($(tput cols) - ${SIZE_X_MENU}))
-    SIZE_X_TRANS=$((85<${_max_buff}?"85":${_max_buff}))
+    SIZE_X_TRANS=$((85<${_max_buff}?85:${_max_buff}))
     SIZE_Y_TRANS=$(($(tput lines) - ${POS_Y_MENU}))
 
     # Size for the displayed info in main menu
     SIZE_X_INFO=${SIZE_X_MENU}
     _max_buff=$(($(tput lines) - ${POS_Y_MENU} - ${SIZE_Y_MENU}))
-    SIZE_Y_INFO=$((15<${_max_buff}?"15":${_max_buff}))
+    SIZE_Y_INFO=$((15<${_max_buff}?15:${_max_buff}))
 
     # Size for view all transactions dialog
-    SIZE_X_TRANS_VIEW=$((74<$(tput cols)?"74":$(tput cols)))
+    SIZE_X_TRANS_VIEW=$((74<$(tput cols)?74:$(tput cols)))
     SIZE_Y_TRANS_VIEW=$(tput lines)
 
     POS_X_MENU=$(($(($(tput cols) - ${SIZE_X_MENU} - ${SIZE_X_TRANS})) / 2))
@@ -1010,7 +1010,7 @@ calculateLayout() {
     # not used yet
     TEXTHIGHT_INFO=$(( ${SIZE_Y_INFO} - 2 ))
 
-    SIZE_X_GAUGE=$((60<$(tput cols)?"60":$(tput cols)))
+    SIZE_X_GAUGE=$((60<$(tput cols)?60:$(tput cols)))
     SIZE_Y_GAUGE=0
     #
     TITLE_BACK="Spectrecoin Bash RPC Wallet Interface ($VERSION)"


### PR DESCRIPTION
Scripts fails on Linux Mint 18.3 with GNU bash, version 4.3.46(1)-release (x86_64-pc-linux-gnu)
`spectrecoin_rpc_ui.sh: line 972: 45>67?"45":67: syntax error: operand expected (error token is ""45":67")`

I am not able to test this solution on other bash versions (specially on Rasbian)